### PR TITLE
bug fixing - I2C code rework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ endif
 CC			= avr-gcc
 
 CDEFINES	+= -DUSE_SLEEP
+CDEFINES	+= -DUSE_LEDREAD
 
 # Override is only needed by avr-lib build system.
 override ASFLAGS	= -Wall $(OPTIMIZE) $(CDEFINES) -mmcu=$(MCU_TARGET)

--- a/main.c
+++ b/main.c
@@ -51,10 +51,9 @@
 #define set(port,x) port |= (x)
 #define clr(port,x) port &= ~(x)
 
-extern void draw_loop();
-extern void clear_gain(void);
-extern void delay(uint8_t ticks);
+extern void draw_loop(void);
 extern void check_keys(void);
+extern void delay(uint8_t ticks);
 
 /*	bit count values for LED2472G shift register
 **	LED_LE must rise after transmitting n-th bit
@@ -77,22 +76,33 @@ extern uint32_t read_data(le_key type);
 /*	I2C register addresses
 */
 enum REG_ADDR {
+	// LED pixels buffers
 	REG_PIXELS=0, REG_PIXELS_MAX=((8*8*3)-1),
 	/*	unused - left from initial version
 	REG_ID = 192,
 	REG_CFG_LOW,
 	REG_CFG_HIGH,
 	*/
+	// data from LED2472G shift register (high byte at high address, evenly aligned)
+	REG_LED_CFG=0xC0,							// configuration registers (24+8 bit)
+	REG_LED_GAIN=0xC4,							// gain (24+8 bit)
+	REG_LED_ERROR=0xC8,							// error open/short detection (24+8 bit)
+	REG_LED_THERMAL=0xCC,						// thermal alert (24+8 bit)
+#ifndef NDEBUG
+	// debugging registers
 	REG_PINA=0xE0, REG_DDRA, REG_PORTA,
 	REG_PINB, REG_DDRB, REG_PORTB,
 	REG_PINC, REG_DDRC, REG_PORTC,
 	REG_PIND, REG_DDRD, REG_PORTD,
 	REG_MCUSR, REG_MCUCR,
 	REG_PORTCR, REG_PRR,
+#endif
+	// administrative registers
 	REG_WAI=0xF0, REG_VER=0xF1,
 	REG_KEYS=0xF2,
 	REG_EE_WP=0xF3,
-	REG_WDTCSR=0xF4, REG_SMCR=0xf5,
+	REG_WDTCSR=0xF4,
+	REG_SMCR=0xf5,
 	REG_WDC=0xF6,
 };
 
@@ -103,68 +113,92 @@ enum REG_ADDR {
 #	define VERSION	0x01	/* release version */
 #endif
 
-volatile uint8_t registers[0x100] __attribute__ ((aligned (0x100))) = {
-	//	offset 0x00 - line 1
-	0x1F, 0x1F, 0x1F, 0x1F, 0x14, 0x03, 0x00, 0x00,	// red 1-8
-	0x00, 0x00, 0x03, 0x12, 0x1F, 0x1F, 0x1F, 0x1F,	// green 1-8
-	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07,	// blue 1-8
-	//	offset 0x18 - line 2
-	0x1F, 0x1F, 0x1F, 0x12, 0x03, 0x00, 0x00, 0x00,	// red 9-16
-	0x00, 0x04, 0x14, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F,	// green 9-16
-	0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x1D,	// blue 9-16
-	//	offset 0x30 - line 3
-	0x1F, 0x1F, 0x11, 0x02, 0x00, 0x00, 0x00, 0x00,	// red 17-24
-	0x05, 0x15, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x0B,	// green 17-24
-	0x00, 0x00, 0x00, 0x00, 0x00, 0x09, 0x1F, 0x1F,	// blue 17-24
-	//	offset 0x48 - line 4
-	0x1F, 0x0F, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,	// red 25-32
-	0x17, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x0A, 0x00,	// green 25-32
-	0x00, 0x00, 0x00, 0x00, 0x0A, 0x1F, 0x1F, 0x1F,	// blue 25-32
-	//	offset 0x60 - line 5
-	0x0E, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03,	// red 33-40
-	0x1F, 0x1F, 0x1F, 0x1F, 0x1D, 0x08, 0x00, 0x00,	// green 33-40
-	0x00, 0x00, 0x01, 0x0B, 0x1F, 0x1F, 0x1F, 0x1F,	// blue 33-40
-	//	offset 0x78 - line 6
-	0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x14,	// red 41-48
-	0x1F, 0x1F, 0x1F, 0x1B, 0x07, 0x00, 0x00, 0x00,	// green 41-48
-	0x00, 0x01, 0x0C, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F,	// blue 41-48
-	//	offset 0x90 - line 7
-	0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x15, 0x1F,	// red 49-56
-	0x1F, 0x1F, 0x19, 0x06, 0x00, 0x00, 0x00, 0x00,	// green 49-56
-	0x02, 0x0E, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x12,	// blue 49-56
-	//	offset 0xA8 - line 8
-	0x00, 0x00, 0x00, 0x00, 0x05, 0x17, 0x1F, 0x1F,	// red 57-64
-	0x1F, 0x17, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00,	// green 57-64
-	0x0F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x0F, 0x02,	// blue 57-64
-	//	offset 0xC0
-	0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7,
-	0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF,
-	//	offset 0xD0
-	0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7,
-	0xD8, 0xD9, 0xDA, 0xDB, 0xDC, 0xDD, 0xDE, 0xDF,
-	//	offset 0xE0
-	0xE0, 0xE1, 0xE2,					// PORTA
-	0xE3, 0xE4, 0xE5,					// PORTB
-	0xE6, 0xE7, 0xE8,					// PORTC
-	0xE9, 0xEA, 0xEB,					// PORTD
-	0xEC,								// MCUSR
-	0xED,								// MCUCR
-	0xEE,								// PORTCR
-	0xEF,								// PRR
-	//	offset 0xF0
-	I2C_ID, VERSION,					// Who-Am-I and firmware version
-	0xF2,								// keys
-	0xF3,								// EEPROM write protect disabled
-	0xF4, 0xF5, 0xF6, 0xF7,
-	0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF,
-};
+typedef union
+{
+	uint8_t		ui8 [0x100];
+	uint16_t	ui16[0x100 >>1];
+	uint32_t	ui32[0x100 >>2];
+}	I2C_PAGE_BUFFER;
+
+volatile	I2C_PAGE_BUFFER	registers = { .ui8 = {
+//	offset 0x00 - line 1
+0x1F, 0x1F, 0x1F, 0x1F, 0x14, 0x03, 0x00, 0x00,	// red 1-8
+0x00, 0x00, 0x03, 0x12, 0x1F, 0x1F, 0x1F, 0x1F,	// green 1-8
+0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x07,	// blue 1-8
+//	offset 0x18 - line 2
+0x1F, 0x1F, 0x1F, 0x12, 0x03, 0x00, 0x00, 0x00,	// red 9-16
+0x00, 0x04, 0x14, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F,	// green 9-16
+0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x08, 0x1D,	// blue 9-16
+//	offset 0x30 - line 3
+0x1F, 0x1F, 0x11, 0x02, 0x00, 0x00, 0x00, 0x00,	// red 17-24
+0x05, 0x15, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x0B,	// green 17-24
+0x00, 0x00, 0x00, 0x00, 0x00, 0x09, 0x1F, 0x1F,	// blue 17-24
+//	offset 0x48 - line 4
+0x1F, 0x0F, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00,	// red 25-32
+0x17, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x0A, 0x00,	// green 25-32
+0x00, 0x00, 0x00, 0x00, 0x0A, 0x1F, 0x1F, 0x1F,	// blue 25-32
+//	offset 0x60 - line 5
+0x0E, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03,	// red 33-40
+0x1F, 0x1F, 0x1F, 0x1F, 0x1D, 0x08, 0x00, 0x00,	// green 33-40
+0x00, 0x00, 0x01, 0x0B, 0x1F, 0x1F, 0x1F, 0x1F,	// blue 33-40
+//	offset 0x78 - line 6
+0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0x14,	// red 41-48
+0x1F, 0x1F, 0x1F, 0x1B, 0x07, 0x00, 0x00, 0x00,	// green 41-48
+0x00, 0x01, 0x0C, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F,	// blue 41-48
+//	offset 0x90 - line 7
+0x00, 0x00, 0x00, 0x00, 0x00, 0x04, 0x15, 0x1F,	// red 49-56
+0x1F, 0x1F, 0x19, 0x06, 0x00, 0x00, 0x00, 0x00,	// green 49-56
+0x02, 0x0E, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x12,	// blue 49-56
+//	offset 0xA8 - line 8
+0x00, 0x00, 0x00, 0x00, 0x05, 0x17, 0x1F, 0x1F,	// red 57-64
+0x1F, 0x17, 0x05, 0x00, 0x00, 0x00, 0x00, 0x00,	// green 57-64
+0x0F, 0x1F, 0x1F, 0x1F, 0x1F, 0x1F, 0x0F, 0x02,	// blue 57-64
+//	offset 0xC0
+0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7,
+0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF,
+//	offset 0xD0
+0xD0, 0xD1, 0xD2, 0xD3, 0xD4, 0xD5, 0xD6, 0xD7,
+0xD8, 0xD9, 0xDA, 0xDB, 0xDC, 0xDD, 0xDE, 0xDF,
+//	offset 0xE0
+0xE0, 0xE1, 0xE2,					// PINA,DDRA,PORTA
+0xE3, 0xE4, 0xE5,					// PINB,DDRB,PORTB
+0xE6, 0xE7, 0xE8,					// PINC,DDRC,PORTC
+0xE9, 0xEA, 0xEB,					// PIND,DDRD,PORTD
+0xEC,								// MCUSR
+0xED,								// MCUCR
+0xEE,								// PORTCR
+0xEF,								// PRR
+//	offset 0xF0
+I2C_ID, VERSION,					// Who-Am-I and firmware version
+0xF2,								// keys
+0xF3,								// EEPROM write protect disabled
+0xF4,								// watchdog timer control register wdt_reg
+0xF5,								// SMCR Sleep Mode Control Register
+0xF6,								// I2C_WDC watchdog interrupt counter
+0xF7,
+0xF8, 0xF9, 0xFA, 0xFB, 0xFC, 0xFD, 0xFE, 0xFF,
+}};
+
 //	some defines, to ease access
-#define pixels		registers[REG_PIXELS]
-#define keys		registers[REG_KEYS]
-#define watchdog	registers[REG_WDC]
+#define	reg_ui8(pos)	(registers.ui8[pos])
+#define	reg_ui16(pos)	(registers.ui16[pos >>1])
+#define	reg_ui32(pos)	(registers.ui32[pos >>2])
+#define pixels			(reg_ui8(REG_PIXELS))
+#define keys			(reg_ui8(REG_KEYS))
+#define watchdog		(reg_ui8(REG_WDC))
+#define wdt_reg			(reg_ui8(REG_WDTCSR))
+#define sm_reg			(reg_ui8(REG_SMCR))
+#ifdef	USE_LEDREAD
+#	define LED_CFG		(reg_ui32(REG_LED_CFG))
+#	define LED_GAIN		(reg_ui32(REG_LED_GAIN))
+#	define LED_ERROR	(reg_ui32(REG_LED_ERROR))
+#	define LED_THERMAL	(reg_ui32(REG_LED_THERMAL))
+#endif
 
 volatile uint8_t i2c_reg	= 0xFF;		// I2C register address
 volatile char i2c_busy		= 1;		// I2C transactions in progress - bit0 =active, bit1 =DATA is address
+#define I2C_BUSY_INPROGRESS	(1 << 0)	// transaction in progress - sometimes between START and STOP
+#define I2C_BUSY_ADDRESS	(1 << 1)	// next DATA is register address
 volatile char redrawleds	= 1;		// redraw LEDs after pixels has been updated
 
 ISR(BADISR_vect, ISR_NAKED)
@@ -191,8 +225,7 @@ ISR(ANALOG_COMP_vect, ISR_ALIASOF(BADISR_vect));
 ISR(TIMER0_OVF_vect)
 {
 	//	without attribute ISR_NAKED registers get pushed, popped and RETI gets added
-	redrawleds	= 1;			// set flag to redraw LEDs
-	TIFR0		= 0;			// clear interrupt flag register
+	redrawleds	= 1;					// set flag to redraw LEDs
 }
 ISR(TIMER0_COMPA_vect, ISR_ALIASOF(TIMER0_OVF_vect));
 ISR(TIMER0_COMPB_vect, ISR_ALIASOF(TIMER0_OVF_vect));
@@ -204,12 +237,83 @@ ISR(WDT_vect)
 	++watchdog;					// count
 	redrawleds	= 1;			// set flag to redraw LEDs
 	MCUSR	&= ~(1 << WDRF);	// clear watchdog reset flag
-	/*	WDIF is cleared by hardware when executing the corresponding interrupt handling vector.
-	WDTCSR	|= (1 << WDIF);		// clear interrupt flag - with writing logic 1 to WDIF
-	*/
 }
 
-/*	defined in rpi-sense.S	ISR(TWI_vect, ISR_ALIASOF(BADISR_vect));*/
+/*	defined in rpi-sense.S
+ISR(TWI_vect)
+{
+	twi_busy	|= 1;							// set i2c_busy flag
+	wdt_reset();								// reset watchdog timer
+
+	switch(TW_STATUS)
+	{
+
+	//	MASTER
+	case TW_START:								// START condition transmitted
+	case TW_REP_START:							// REPEATED START condition transmitted
+		break;
+
+	// MASTER RECEIVER
+	case TW_MR_ARB_LOST:						// arbitration lost in SLA+R or NACK
+		GOTO	lbl_TWI_RESET;					// stop/reset the TWI system
+	case TW_MR_SLA_ACK:							// SLA+R transmitted, ACK received
+	case TW_MR_DATA_ACK:						// DATA received, ACK returned
+		break;
+	case TW_MR_SLA_NACK:						// SLA+R transmitted, NACK received
+	case TW_MR_DATA_NACK:						// DATA received, NACK returned
+		break;
+
+	// MASTER TRANSMITTER
+	case TW_MT_ARB_LOST:						// arbitration lost in SLA+W or DATA
+		GOTO	lbl_TWI_RESET;					// stop/reset the TWI system
+	case TW_MT_SLA_ACK:							// SLA+W transmitted, ACK received
+	case TW_MT_DATA_ACK:						// DATA transmitted, ACK received
+		break;
+	case TW_MT_SLA_NACK:						// SLA+W transmitted, NACK received
+	case TW_MT_DATA_NACK:						// DATA transmitted, NACK received
+		break;
+
+	// SLAVE
+
+	// SLAVE RECEIVER
+	case TW_SR_ARB_LOST_SLA_ACK:				// arbitration lost in SLA+RW, SLA+W received, ACK returned
+	case TW_SR_ARB_LOST_GCALL_ACK:				// arbitration lost in SLA+RW, general call received, ACK returned
+		GOTO	lbl_TWI_RESET;					// stop/reset the TWI system
+	case TW_SR_SLA_ACK:							// SLA+W received, ACK returned
+		i2c_busy	|= I2C_BUSY_ADDRESS;		// next DATA received is register address
+	case TW_SR_DATA_ACK:						// data received, ACK returned
+	case TW_SR_GCALL_ACK:						// general call received, ACK returned
+	case TW_SR_GCALL_DATA_ACK:					// general call data received, ACK returned
+		break;
+	case TW_SR_DATA_NACK:						// data received, NACK returned
+	case TW_SR_GCALL_DATA_NACK:					// general call data received, NACK returned
+	case TW_SR_STOP:							// stop or repeated start condition received while selected
+		break;
+
+	// SLAVE TRANSMITTER
+	case TW_ST_ARB_LOST_SLA_ACK:				// arbitration lost in SLA+RW, SLA+R received, ACK returned
+		GOTO	lbl_TWI_RESET;					// stop/reset the TWI system
+	case TW_ST_SLA_ACK:							// SLA+R received, ACK returned
+		i2c_busy	|= I2C_BUSY_ADDRESS;		// next DATA received is register address
+	case TW_ST_DATA_ACK:						// data transmitted, ACK received
+		break;
+	case TW_ST_DATA_NACK:						// data transmitted, NACK received
+	case TW_ST_LAST_DATA:						// last data byte transmitted, ACK received
+		break;
+
+	// ERROR CONDITIONS
+	case TW_BUS_ERROR:							// illegal START or STOP condition
+	case TW_NO_INFO:							// no state information available
+		GOTO	lbl_TWI_RESET;					// stop/reset the TWI system
+
+	default:
+lbl_TWI_RESET:
+		TWCR	|= (1 << TWSTO);				// MASTER generate STOP, SLAVE release to recover from error
+	}
+
+	TWCR	|= (1 << TWINT);					// clear TWINT flag and start TWI operation
+}
+*/
 
 __fuse_t __fuse __attribute__((section (".fuse"))) =
 {
@@ -245,6 +349,8 @@ __fuse_t __fuse __attribute__((section (".fuse"))) =
 */
 int main(void)
 {
+	uint8_t _looping = 0;					// local counter variable for main working loop
+
 	// define pull-up values
 	//MCUCR	|= (1 << PUD);					// disable pull-up resistors
 	PORTA	= 0;
@@ -266,6 +372,7 @@ int main(void)
 	**	use TIMER0 for regularly LED updates wont work, if using SLEEP
 	**	TIMER0 wont run in power down mode, but in idle
 	**	CS0:	0=disabled, 1=clkIO, 2=clkIO/8, 3=clkIO/64, 4=clkIO/256, 5=clkIO/1024, 6=T0 pin falling, 7=T0 pin rising
+	**	TOV0 interrupt with prescaler==5 every 32768ns ca. 30Hz
 	*/
 	TCNT0	= 0;							// clear timer0 counter register
 	OCR0A	= 0;							// clear timer0 output compare register
@@ -295,70 +402,71 @@ int main(void)
 	/*	configure SLEEP mode
 	**	sleep modes - 0b10=power-down, 0b01=ADC noise reduction, 0b00=IDLE
 	*/
-#ifdef USE_SLEEP
-	SMCR	= (1 << SM1) | (0 << SM0) | (0 << SE);	// enable SLEEP to power-down mode
-#else
 	SMCR	= (0 << SM1) | (0 << SM0) | (0 << SE);	// enable SLEEP to IDLE mode
-#endif	// USE_SLEEP
 
 	//	disable TIMER1,SPI,ADC clock for power reduction
 	PRR		= (0 << PRTWI) | (0 << PRTIM0) | (1 << PRTIM1) | (1 << PRSPI) | (1 << PRADC);
 
-	write_data((1 << 6), CONF_WRITE);		//	configure LED2472G shift register
-	/*	just for testing - little/big endian register alignment needs to be checked
-	read_data(CONF_READ);
-	asm volatile("STS registers+0xC0, r25");
-	asm volatile("STS registers+0xC1, r24");
-	asm volatile("STS registers+0xC2, r23");
-	asm volatile("STS registers+0xC3, r22");
-	*/
+#	ifdef	USE_LEDREAD
+	LED_CFG		= (1 << 6);					//	enable LED drivers auto-off
+	write_data(LED_CFG, CONF_WRITE);		//	configure LED2472G shift register
+	LED_GAIN	= 0;
+	write_data(LED_GAIN, GAIN_WRITE);		//	clear LED2472G shift register gain
+#	else
+	write_data(0x00000040, CONF_WRITE);		//	configure LED2472G shift register
+	write_data(0x00000000, GAIN_WRITE);		//	clear LED2472G shift register gain
+#	endif
 
-	for(;;)
+	for(_looping = 0; ; _looping++)
 	{
 		wdt_reset();						// reset watchdog timer
 		sei();								// Set Enable global Interrupts
 
+#ifdef UNUSED_CODE
+		//while(0 == (TWCR & (1 << TWINT)))	// TWINT flag not set
 		while(0 != i2c_busy)
 		{
 			//	just wait for I2C operation to finish
 			delay(200);						// (clkT0=8kHz, 200/8000=1/40s =25ms
 		}
-
-#ifdef UNUSED_CODE
-		//clear_gain();
-		if(0 == redrawleds)
-		{
-			check_keys();					// skip LED update and only check joystick
-		}
-		else
 #endif
-		{
-			draw_loop();					// copy pixels to LED shift register
-			// draw_loop always finishes with check_keys
-		}
 
-		registers[REG_EE_WP]	= ((PORTB & EE_WP) ?0 :1);	// copy EEPROM_WP disabled to I2C data buffer
-		registers[REG_WDTCSR]	= WDTCSR;	// copy register to I2C data buffer
-		registers[REG_SMCR]		= SMCR;		// copy register to I2C data buffer
-#ifndef NDEBUG
+		draw_loop();						// copy pixels to LED shift register
+
+		registers.ui8[REG_EE_WP]	= ((PORTB & EE_WP) ?0 :1);	// copy EEPROM_WP disabled to I2C data buffer
+		registers.ui8[REG_WDTCSR]	= WDTCSR;	// copy register to I2C data buffer
+		registers.ui8[REG_SMCR]		= SMCR;		// copy register to I2C data buffer
+
+#		ifndef NDEBUG
 		// copy registers to I2C data buffer
-		registers[REG_PINA]		= PINA;
-		registers[REG_DDRA]		= DDRA;
-		registers[REG_PORTA]	= PORTA;
-		registers[REG_PINB]		= PINB;
-		registers[REG_DDRB]		= DDRB;
-		registers[REG_PORTB]	= PORTB;
-		registers[REG_PINC]		= PINC;
-		registers[REG_DDRC]		= DDRC;
-		registers[REG_PORTC]	= PORTC;
-		registers[REG_PIND]		= PIND;
-		registers[REG_DDRD]		= DDRD;
-		registers[REG_PORTD]	= PORTD;
-		registers[REG_MCUSR]	= MCUSR;
-		registers[REG_MCUCR]	= MCUCR;
-		registers[REG_PORTCR]	= PORTCR;
-		registers[REG_PRR]		= PRR;
-#endif	// NDEBUG
+		registers.ui8[REG_PINA]		= PINA;
+		registers.ui8[REG_DDRA]		= DDRA;
+		registers.ui8[REG_PORTA]	= PORTA;
+		registers.ui8[REG_PINB]		= PINB;
+		registers.ui8[REG_DDRB]		= DDRB;
+		registers.ui8[REG_PORTB]	= PORTB;
+		registers.ui8[REG_PINC]		= PINC;
+		registers.ui8[REG_DDRC]		= DDRC;
+		registers.ui8[REG_PORTC]	= PORTC;
+		registers.ui8[REG_PIND]		= PIND;
+		registers.ui8[REG_DDRD]		= DDRD;
+		registers.ui8[REG_PORTD]	= PORTD;
+		registers.ui8[REG_MCUSR]	= MCUSR;
+		registers.ui8[REG_MCUCR]	= MCUCR;
+		registers.ui8[REG_PORTCR]	= PORTCR;
+		registers.ui8[REG_PRR]		= PRR;
+#		endif	// NDEBUG
+
+#		ifdef	USE_LEDREAD
+		if(0 == (_looping & 0x7F))
+		{
+			//	only every 128 loop runs
+			LED_CFG		= read_data(CONF_READ);
+			LED_GAIN	= read_data(GAIN_READ);
+			LED_ERROR	= read_data(DET_OPEN_SHORT);
+			LED_THERMAL	= read_data(THERM_READ);
+		}
+#		endif
 
 #ifdef USE_SLEEP
 		if(0 == i2c_busy && 0 == redrawleds)

--- a/rpi-sense.S
+++ b/rpi-sense.S
@@ -137,28 +137,30 @@ TWI_vect:	// ISR, global interrupts disabled on entry
 	LDS		I2C_OFF, i2c_reg			; I2C_OFF holds previous register address
 	; check TWSR status register
 	LDS		PARAM, TWSR					; load status register
-	ANDI	PARAM, TW_STATUS_MASK		; mask out 
+	ANDI	PARAM, TW_STATUS_MASK		; mask out pre-scaler bits
+	CPI		PARAM, TW_SR_DATA_ACK		; data received, ACK returned
+	BREQ	lreceive					; read DATA from master
+	CPI		PARAM, TW_ST_DATA_ACK		; data transmitted, ACK received
+	BREQ	ltsend						; send DATA to master
+	CPI 	PARAM, TW_SR_STOP			; stop or repeated start condition received while selected
+	BREQ	TWI_stop
+	CPI 	PARAM, TW_ST_LAST_DATA		; last data byte transmitted, ACK received
+	BREQ	TWI_stop
+	CPI		PARAM, TW_SR_SLA_ACK		; SLA+W received, ACK returned
+	BREQ	lrsla						; next DATA is register address
+	CPI		PARAM, TW_ST_SLA_ACK		; SLA+R received, ACK returned
+	BREQ	ltsend						; send current DATA to master
+	CPI 	PARAM, TW_SR_DATA_NACK		; data received, NACK returned
+	BREQ	TWI_stop
+	CPI		PARAM, TW_ST_DATA_NACK		; data transmitted, NACK received
+	BREQ	ltdnack
+
 	;TW_BUS_ERROR	; illegal start or stop condition
 	;TW_NO_INFO	; no state information available
 	// slave transmitter
-	CPI		PARAM, TW_ST_SLA_ACK		; SLA+R received, ACK returned
-	BREQ	ltack						; next DATA is register address
-	CPI		PARAM, TW_ST_DATA_ACK		; data transmitted, ACK received
-	BREQ	ltsend
-	CPI		PARAM, TW_ST_DATA_NACK		; data transmitted, NACK received
-	BREQ	ltdnack
-	CPI 	PARAM, TW_ST_LAST_DATA		; last data byte transmitted, ACK received
-	BREQ	TWI_stop
 	;CPI 	PARAM, TW_ST_ARB_LOST_SLA_ACK	; arbitration lost in SLA+RW, SLA+R received, ACK returned
 	// slave receiver
-	CPI		PARAM, TW_SR_DATA_ACK		; data received, ACK returned
-	BREQ	lreceive
-	CPI 	PARAM, TW_SR_DATA_NACK		; data received, NACK returned
-	BREQ	TWI_stop
-	CPI		PARAM, TW_SR_SLA_ACK		; SLA+W received, ACK returned
-	BREQ	lrack						; next DATA is register address
-	CPI 	PARAM, TW_SR_STOP			; stop or repeated start condition received while selected
-	BREQ	TWI_stop
+	// I2C spec: "If two or more masters try to put information onto the bus, the first to produce a ‘one’ when the other produces a ‘zero’ will lose the arbitration"
 	;CPI 	PARAM, TW_SR_ARB_LOST_GCALL_ACK	; arbitration lost in SLA+RW, general call received, ACK returned
 	;CPI 	PARAM, TW_SR_ARB_LOST_SLA_ACK	; arbitration lost in SLA+RW, SLA+W received, ACK returned
 	;CPI 	PARAM, TW_SR_GCALL_ACK		; general call received, ACK returned
@@ -166,62 +168,36 @@ TWI_vect:	// ISR, global interrupts disabled on entry
 	;CPI 	PARAM, TW_SR_GCALL_DATA_NACK	; general call data received, NACK returned
 	; without TWEA set the next transaction will be NACKed
 	LDI		PARAM,  (0<<TWEA) | (1<<TWEN) | (1<<TWIE) | (1<<TWINT)
-	RJMP	ldone
+ldone:
+	STS		TWCR, PARAM					; load PARAM to TWCR
+	WDR		; reset watchdog timer
+	; restore registers
+	OUT		_SFR_IO_ADDR(SREG), PWM
+	POP		I2C_OFF
+	POP		YH
+	POP		YL
+	POP		PWM
+	POP		PARAM
+	RETI	; return from ISR and global interrupt enable
 
-lrack:	; SLA+W, ACK sent
+lrsla:		; SLA+W received, ACK sent
 	LDS		PARAM, i2c_busy				; load i2c_busy flags
-	SBI		PARAM, 2					; set write transaction flag
-	RJMP	.+4							; skip LDS 4byte instruction
-ltack:	; SLA+R, ACK sent
-	LDS		PARAM, i2c_busy				; load i2c_busy flags
-	SBI		PARAM, 1					; set next DATA is address flag
+	ORI		PARAM, 0b00000010			; set next DATA is address flag
 	STS		i2c_busy, PARAM				; store i2c_busy flags
-	LDI		PARAM,  (1<<TWEA) | (1<<TWEN) | (1<<TWIE) | (1<<TWINT)
-	RJMP	ldone
-ltdnack:	; NACK received
-	LDI		PARAM,  (1<<TWEA) | (1<<TWEN) | (1<<TWIE) | (1<<TWINT)
+	CLR		I2C_OFF						; reset I2C_OFF to first register I2C_OFF=0x00
+	LDI		PARAM, (1<<TWEA) | (1<<TWEN) | (1<<TWIE) | (1<<TWINT)
 	RJMP	ldone
 
 ltsend:		; DATA sent
 	RJMP	TWI_read					; transmit data to master
-lreceive:	; DATA received
-	LDS		PARAM, i2c_busy				; load i2c_busy flags
-	SBIS	PARAM, 1					; skip if DATA is address
-	RJMP	TWI_write					; receive data from master
-lraddress:	; DATA==address
-	LDI		I2C_OFF, 1					; set i2c_busy flag
-	STS		i2c_busy, I2C_OFF			; store i2c_busy=1 flag, following data is real DATA
-	LDS		I2C_OFF, TWDR				; load DATA - register address
-	STS		i2c_reg, I2C_OFF			; address = DATA
-	; now address could be check with available addresses and TWEA disabled if unknown address
-	CPI		I2C_OFF, (8*8*3)			; address<(8*8*3) pixels buffer
-	BRLO	lrsregOK					; address valid
-#ifndef NDEBUG
-	CPI		I2C_OFF, 0xE0				; address < 0xE0 (&& >=192) debug registers
-#else
-	CPI		I2C_OFF, I2C_WAI			; address < 0xF0 (&& >=192) Who-Am-I
-#endif
-	BRLO	lrsregNOK					; address invalid
-	; now address (>= 0xE0/F0) must be checked for read/write
-	SBIS	PARAM, 2					; skip if write transaction flag is set
-	RJMP	lrsregread					; read is possible for all registers
-	; check write address
-	CPI		I2C_OFF, I2C_EE_WP			; address==0xF3 EEPROM write protection
-	BREQ	lrsregOK					; address valid
-	RJMP	lrsregNOK					; address invalid
-lrsregread:
-	CPI		I2C_OFF, I2C_WDC +1			; address<=0xF6 watchdog counter
-	BRLO	lrsregOK					; address invalid
-lrsregNOK:
-	; for real NACK TWEA=0 must be set to disable ACK
-	LDI		PARAM,  (0<<TWEA) | (1<<TWEN) | (1<<TWIE) | (1<<TWINT)
-	RJMP	ldone						; return and continue at ldone
-lrsregOK:
+
+ltdnack:	; NACK received
+	;		just ignore NACK and wait for next transaction - most probably STOP condition
 	LDI		PARAM,  (1<<TWEA) | (1<<TWEN) | (1<<TWIE) | (1<<TWINT)
-	RJMP	ldone						; return and continue at ldone
+	RJMP	ldone
 
 TWI_NACK:	; send NACK on next receive
-	LDI		PARAM,  (0<<TWEA) | (1<<TWEN) | (1<<TWIE) | (1<<TWINT)
+	LDI		PARAM, (0<<TWEA) | (1<<TWEN) | (1<<TWIE) | (1<<TWINT)
 	RJMP	ldone
 TWI_reset:
 	LDS		PARAM,	TWCR				; load TWCR register
@@ -238,32 +214,56 @@ TWI_stop:
 	STS		i2c_busy, PARAM				; i2c_busy=0
 	LDI		PARAM,  (1<<TWEA) | (1<<TWEN) | (1<<TWIE) | (1<<TWINT)
 	RJMP	ldone
-ldone:
-	STS		TWCR, PARAM					; load PARAM to TWCR
-	WDR		; reset watchdog timer
-	; restore registers
-	OUT		_SFR_IO_ADDR(SREG), PWM
-	POP		I2C_OFF
-	POP		YH
-	POP		YL
-	POP		PWM
-	POP		PARAM
-	RETI	; return from ISR and global interrupt enable
+
+lreceive:	; slave receive DATA received
+	LDS		PARAM, i2c_busy				; load i2c_busy flags
+	SBRS	PARAM, 1					; skip if DATA is address - i2c_busy.1==1
+	RJMP	TWI_write					; i2c_busy.address==0 receive data from master
+lraddress:	; slave receive DATA==address
+	LDI		I2C_OFF, 1					; set i2c_busy flag
+	STS		i2c_busy, I2C_OFF			; store i2c_busy=1 flag, following data is real DATA
+	LDS		I2C_OFF, TWDR				; load DATA - register address
+	STS		i2c_reg, I2C_OFF			; i2c_reg = DATA, register address for coming read transactions
+	; now address could be check with available addresses and TWEA disabled if unknown address
+#ifdef	USE_LEDREAD
+	CPI		I2C_OFF, (8*8*3)+(4*4)		; address < (8*8*3) pixels + (4*4) LED registers
+#else
+	CPI		I2C_OFF, (8*8*3)			; address<(8*8*3) pixels buffer
+#endif
+	BRLO	lrsregOK					; address valid
+#ifndef NDEBUG
+	CPI		I2C_OFF, 0xE0				; address < 0xE0 (&& >=192) debug registers
+#else
+	CPI		I2C_OFF, I2C_WAI			; address < 0xF0 (&& >=192) Who-Am-I
+#endif
+	CPI		I2C_OFF, I2C_WDC +1			; address<=0xF6 watchdog counter
+	BRLO	lrsregOK					; address invalid
+	; other addresses are invalid
+lrsregNOK:
+	; for real NACK TWEA=0 must be set to disable ACK
+	LDI		PARAM, (0<<TWEA) | (1<<TWEN) | (1<<TWIE) | (1<<TWINT)
+	RJMP	ldone						; return and continue at ldone
+lrsregOK:
+	LDI		PARAM, (1<<TWEA) | (1<<TWEN) | (1<<TWIE) | (1<<TWINT)
+	RJMP	ldone						; return and continue at ldone
 .endfunc
 
 .func	TWI_read
-TWI_read:
+TWI_read:	; TWI slave receiver
 	; read data @I2C_OFF and write to TWDR, return new TWCR value in PARAM
-	CPI     I2C_OFF, 192				; if address<192
+	; always increment I2C_OFF for next transaction
+#ifdef	USE_LEDREAD
+	CPI		I2C_OFF, (8*8*3)+(4*4)		; address < (8*8*3) pixels + (4*4) LED registers
+#else
+	CPI		I2C_OFF, (8*8*3)			; address<(8*8*3) pixels buffer
+#endif
 	BRLO    ltsreg
-
 #ifndef	NDEBUG
 	CPI		I2C_OFF, 0xE0				; registers 0xE0-0xEB
 	BRLO	ltsnack						; <0xE0
 	CPI		I2C_OFF, 0xF0
 	BRLO	ltsreg						; 0xE0 <= I2C_OFF <= 0xEF
 #endif
-
 	CPI     I2C_OFF, I2C_KEYS			; if address==I2C_KEYS
 	BRLO	ltsreg						; address < I2C_KEYS
 	BREQ    ltskeys
@@ -271,16 +271,26 @@ TWI_read:
 	BREQ    ltsee
 	CPI     I2C_OFF, I2C_WDC +1			; if address<=I2C_WDC
 	BRLO    ltsreg						; address <= I2C_WDC
+
 ltsnack:
-	STS		TWDR, I2C_OFF					; simply send back address
+#ifndef NDEBUG
+	COM		I2C_OFF
+	STS		TWDR, I2C_OFF					; simply send back complement of address
+	COM		I2C_OFF
+#else
+	LDI		TWDR, 0xFF						; all bits high like pulled-up
+#endif
 	INC     I2C_OFF							; increment offset
 	STS     i2c_reg, I2C_OFF				; store offset for next transaction
-	; for real NACK TWEA=0 must be set to disable ACK
+	;		for real NACK TWEA=0 must be set to disable ACK
 	RJMP	ltdone
+
 ltskeys:	// joystick
 	CBI     _SFR_IO_ADDR(PORTB), KEYS_INT	; clear KEYS_INT flag on read
 	RJMP    ltsreg
 ltsee:		// EEPROM write protection
+	INC		I2C_OFF							; increment register offset address
+	STS		i2c_reg, I2C_OFF				; store offset for next transaction
 	CLR		I2C_OFF							; clear
 	SBIS    _SFR_IO_ADDR(PORTB), EE_WP		; skip if EE_WP output set
 	LDI     I2C_OFF, 1						; set 1 if output active-low - write protection disabled
@@ -291,6 +301,8 @@ ltsreg:		; send from register buffer
 	LDI     YL, lo8(registers)				; load low byte buffer addres
 	LDI     YH, hi8(registers)				; load high byte buffer address
 	ADD     YL, I2C_OFF						; add offset to buffer address
+	INC		I2C_OFF							; increment register offset address
+	STS		i2c_reg, I2C_OFF				; store offset for next transaction
 	CLR     I2C_OFF							; clear temporary variable
 	ADC     YH, I2C_OFF						; add 0 and CARRY flag to high byte of address
 	LD      I2C_OFF, Y						; load from register buffer address
@@ -298,14 +310,15 @@ ltsreg:		; send from register buffer
 	RJMP    ltdone
 
 ltdone:
-	LDI	PARAM,  (1<<TWEA) | (1<<TWEN) | (1<<TWIE) | (1<<TWINT)
+	LDI		PARAM,  (1<<TWEA) | (1<<TWEN) | (1<<TWIE) | (1<<TWINT)
 	WDR		; reset watchdog timer
 	RJMP	ldone
 .endfunc
 
 .func	TWI_write
-TWI_write:
+TWI_write:	; TWI slave transmitter
 	; write data from TWDR to @I2C_OFF, return new TWCR value in PARAM
+	; always increment I2C_OFF for next transaction
 	LDS		PARAM, TWDR				; Data
 	CPI		I2C_OFF, 192			; if address<192
 	BRLO	lrsregisters			; I2C_OFF < 192
@@ -348,30 +361,6 @@ lrdone:
 
 .func draw_loop
 draw_loop:
-/*	wait for I2C to finish in main
-	WDR		; reset watchdog timer
-while_i2c_busy:
-	LDS		_SFR_IO_ADDR(GPIOR0), i2c_busy
-	CPI		_SFR_IO_ADDR(GPIOR0), 0
-	BRNE	while_i2c_busy
-*/
-/*	unsure, if useful or necessary, so disabled for now
-	LDS		_SFR_IO_ADDR(GPIOR0), TWCR
-	ANDI	_SFR_IO_ADDR(GPIOR0), (1 << TWINT)
-	BRNE 	while_i2c_busy		; TWINT set if i2c operation finished
-*/
-/*	unnecessary to configure PORTD here
-	LDI		LINE, 0xFF						; LINE=0xFF
-	OUT		_SFR_IO_ADDR(DDRD), LINE		; switch PORTD to output
-	COM		LINE							; LINE=0
-	OUT		_SFR_IO_ADDR(PORTD), LINE		; switch PORTD active-low
-*/
-	WDR		; reset watchdog timer
-	;	check if update is needed
-	LDS		LINE, redrawleds				; redrawleds needed, after pixels update
-	CPI		LINE, 0
-	BRNE	.+2								; (FIX HACK) relocation truncated to fit: R_AVR_7_PCREL against `no symbol'
-	RJMP	check_keys						; skip update and continue to joystick
 	CLR		LINE
 	STS		redrawleds, LINE				; clear flag redrawleds=0
 Lframe_loop:
@@ -434,15 +423,19 @@ Lpwm_loop:
 	COL_OUT	r22
 	COL_OUT	r23
 	CBI		_SFR_IO_ADDR(PORTC), LED_LE		; LE low mark data end
-	INC		PWM								; ++PWM
-	SBRS	PWM, 6							; skip if bit set PWM bit 6
-	RJMP	Lpwm_loop						; next 
+	INC		PWM								; PWM++
+	SBRS	PWM, 6							; skip if bit set PWM bit 6 (64 runs)
+	RJMP	Lpwm_loop						; next
+	SEC		; set CARRY flag and clear if bit7==0 to be sure
+	SBRS	LINE, 7							; skip if bit7==1
+	CLC										; clear CARRY if bit7==0
 	ROL		LINE							; shift LINE with CARRY bit - C=7,7=6,6=5,5=4,4=3,3=2,2=1,1=0,0=C
 	BRCC	lframeend						; branch if CARRY=0 - after 8 loops
-	INC		LINE							; ++LINE
+	INC		LINE							; LINE++
 	RJMP	Lline_loop						; next line output
 lframeend:
 	SBI		_SFR_IO_ADDR(PORTB), FRAME_INT	; raise FRAME_INT interrupt to Pi
+	CBI		_SFR_IO_ADDR(PORTC), LED_OE_N	; /Scan
 
 	; continue with joystick reading
 	RJMP	check_keys
@@ -462,7 +455,7 @@ check_keys:
 	LSR		PARAM
 	LSR		PARAM
 	STS		keys, PARAM						; keys = (PORTD>>3) 000,C,CTR,A,B,D
-	CPSE	PARAM, PWM						; if keys changed
+	CPSE	PARAM, PWM						; if keys changed (compare, skip if equal)
 	SBI		_SFR_IO_ADDR(PORTB), KEYS_INT	; raise KEYS_INT to Pi
 	LDI		PARAM, 0xFF
 	OUT		_SFR_IO_ADDR(DDRD), PARAM		; change PORTD to output
@@ -472,19 +465,19 @@ check_keys:
 	RET		; return control back to main()
 .endfunc
 
-; r24/PARAM = delay for clkT0 ticks
+;	(r25),r24 uint8_t r24/PARAM = delay for clkT0 ticks
 .func delay
 delay:
 	PUSH	r19
 	PUSH	r20
-	IN	r20, _SFR_IO_ADDR(TCNT0)			; start = TCNT0;
+	IN		r20, _SFR_IO_ADDR(TCNT0)			; start = TCNT0;
 lloop:
-	IN	r19, _SFR_IO_ADDR(TCNT0)			; do {
-	SUB	r19, r20							; diff = TCNT0 - start;
-	CP	r19, PARAM							; } while (diff < ticks);
+	IN		r19, _SFR_IO_ADDR(TCNT0)			; do {
+	SUB		r19, r20							; diff = TCNT0 - start;
+	CP		r19, PARAM							; } while (diff < ticks);
 	BRLO	lloop
-	POP	r20
-	POP	r19
+	POP		r20
+	POP		r19
 	RET
  .endfunc
 
@@ -512,10 +505,8 @@ write_data1:								; do {
 write_data2:								; 	else
 	CBI		_SFR_IO_ADDR(PORTC), LED_SDI	;		clr LED_SDI;
 write_data3:
-	/*	clear CARRY unneeded, because value is irrelevant
-	CLC										; clear CARRY
-	**	r25 rotation unneeded, because value is unused
-	ROR		r25								; DATA>>=1; CARRY=0    , bit 31-25, CARRY=bit24
+	/*	r25 rotation unneeded, because value is unused
+	LSR		r25								; DATA>>=1;           0, bit 31-25, CARRY=bit24
 	*/
 	ROR		r24								; DATA>>=1; CARRY=bit24, bit 23-17, CARRY=bit16
 	ROR		r23								; DATA>>=1; CARRY=bit16, bit 15-9 , CARRY=bit8
@@ -564,14 +555,38 @@ read_data:
 	CLR		r22								; DATA=0 for write_data
 	RCALL	write_data
 	; now give time to aquire data
+	MOV		r20, r24						; copy register
+	CPI		r24, 11							; 11==DET_OPEN, 12=DET_SHORT, 13=DET_OPEN_SHORT
+	BRLO	read_data2						; <11 no additional time needed
+	CPI		r24, 14							; 14==THERM_READ
+	BRLO	read_data1						; error detection needs at least 1ys
+	RJMP	read_data2						; >=14 no additional time needed
+read_data1:
+	; error detection needs at least 1ys
+	CBI		_SFR_IO_ADDR(PORTC), LED_OE_N	; When the ROE, GOE and BOE signals become low, error detection starts.
+	PUSH	PARAM							; save PARAM/r24 register
+	LDI		PARAM, 8						; 8 *128ns = 1024ys
+	RCALL	delay							; delay(8) - 1024ys delay
+	POP		PARAM							; restore PARAM/r24 register
+	; after first CLK pulse data will be made available
+read_data2:
 	POP		r20								; restore register
 	POP		r21								; restore register
 	; read data from LED2472G
 	PUSH	r18								; save register
 	LDI		r18, 24							; number of bits to receive
 	CBI		_SFR_IO_ADDR(PORTC), LED_SDI	; clr LED_SDI;
-read_data1:									; do {
+read_data3:									; do {
 	SBI		_SFR_IO_ADDR(PORTC), LED_CLKR	; raise LED_CLKR
+	SBIC	_SFR_IO_ADDR(PORTC), LED_OE_N	; skip if LED_OE_N cleared - first clock
+	RJMP	read_data4						; skip delay
+	CBI		_SFR_IO_ADDR(PORTC), LED_CLKR	; lower LED_CLKR before delay
+	PUSH	PARAM							; save PARAM/r24 register
+	LDI		PARAM, 1						; 1 *128ns
+	RCALL	delay							; delay(1) - 128ys delay
+	POP		PARAM							; restore PARAM/r24 register
+	SBI		_SFR_IO_ADDR(PORTC), LED_OE_N	; kept low for at least 1 ?s
+read_data4:
 	CLC		; clear CARRY
 	SBIC	_SFR_IO_ADDR(PORTC), LED_SDO	; skip if LED_SDO cleared
 	SEC		; set CARRY if LED_SDO is set
@@ -580,10 +595,12 @@ read_data1:									; do {
 	ROL		r23								; DATA<<=1; CARRY=bit16, bit 15-9 , CARRY=bit8
 	ROL		r24								; DATA<<=1; CARRY=bit24, bit 23-17, CARRY=bit16
 	/*	r25 rotation unneeded, because value is unused
+	**	but without rotation value need to be cleared
 	ROL		r25								; DATA<<=1; CARRY=bit32, bit 31-25, CARRY=bit24
 	*/
 	DEC		r18								; 	i--;
-	BRNE	read_data1						; } while (i!=0);
+	BRNE	read_data3						; } while (i!=0);
+	CLR		r25								; unused DATA.31-24=0
 	/*	r25:r24:r23:r22 is return value, save/restore would be a big-bad-bug
 	POP		r22
 	POP		r23


### PR DESCRIPTION
C code hacking for I2C registers buffer (access 8,16,32 bit registers)
removed unnecessary code for optimization
removed power down SLEEP mode
fixed mixed up instructions SBI->ORI and SBIS->SBRS
added timing code to _read_data_ for error detection
added reading of LED2472G registers _#ifdef USE_LEDREAD_
_TWI_vect_ code reorg to check mostly used status codes early
fixed accidential SLA+R reading register address from master